### PR TITLE
Updated mod to work with 1.21.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.8-SNAPSHOT'
 	id 'maven-publish'
 	id "com.modrinth.minotaur" version "2.+"
 }
@@ -41,10 +41,10 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modApi("me.shedaniel.cloth:cloth-config-fabric:15.0.127") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:16.0.141") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
-	modApi "com.terraformersmc:modmenu:11.0.1"
+	modApi "com.terraformersmc:modmenu:12.0.0-beta.1"
 }
 
 processResources {
@@ -100,7 +100,7 @@ modrinth {
 	projectId = 'hotbar3x3'
 	versionNumber = '1.0.0'
 	uploadFile = remapJar
-	gameVersions = ['1.21']
+	gameVersions = ['1.21.2', '1.21.3']
 	loaders = ['fabric']
 	dependencies {
 		required.project 'fabric-api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.3
+yarn_mappings=1.21.3+build.2
+loader_version=0.16.8
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.0+MC1.21.3
 maven_group=nl.lankreijer
 archives_base_name=3x3hotbar
 
 # Dependencies
-fabric_version=0.100.3+1.21
+fabric_version=0.107.3+1.21.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/nl/lankreijer/hotbar3x3/client/InGameHudMixin.java
+++ b/src/client/java/nl/lankreijer/hotbar3x3/client/InGameHudMixin.java
@@ -3,6 +3,7 @@ package nl.lankreijer.hotbar3x3.client;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -17,6 +18,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Function;
 
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
@@ -123,11 +126,11 @@ public abstract class InGameHudMixin {
 		}
 	}
 
-	@Redirect(method="renderHotbar", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 0))
-	private void drawHotbarTexture(DrawContext context, Identifier _texture, int _x, int _y, int _width, int _height) {
+	@Redirect(method="renderHotbar", at=@At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIII)V", ordinal = 0))
+	private void drawHotbarTexture(DrawContext context, Function<Identifier, RenderLayer> renderLayers, Identifier _texture, int _x, int _y, int _width, int _height) {
 		int centerX = context.getScaledWindowWidth() / 2;
 		if (this.hotbarConfig.hotbarMode == Hotbar3x3Config.HotbarMode.VANILLA) {
-			context.drawGuiTexture(HOTBAR_TEXTURE, centerX - SINGLE_HOTBAR_WIDTH / 2, context.getScaledWindowHeight() - SINGLE_HOTBAR_HEIGHT, SINGLE_HOTBAR_WIDTH, SINGLE_HOTBAR_HEIGHT);
+			context.drawGuiTexture(renderLayers, HOTBAR_TEXTURE, centerX - SINGLE_HOTBAR_WIDTH / 2, context.getScaledWindowHeight() - SINGLE_HOTBAR_HEIGHT, SINGLE_HOTBAR_WIDTH, SINGLE_HOTBAR_HEIGHT);
 		} else {
 			context.drawBorder(
 					get3x3HotbarTopLeftX(context), get3x3HotbarTopLeftY(context),
@@ -135,7 +138,7 @@ public abstract class InGameHudMixin {
 					0xFF000000
 			);
 			for (int row = 0; row < 3; row++) {
-				context.drawGuiTexture(HOTBAR_TEXTURE,
+				context.drawGuiTexture(renderLayers, HOTBAR_TEXTURE,
 						SINGLE_HOTBAR_WIDTH /* source texture width */, SINGLE_HOTBAR_HEIGHT /* source texture height */,
 						HOTBAR_BORDER_THICKNESS + row * SINGLE_HOTBAR_WIDTH_BORDERLESS / 3 /* u */ , HOTBAR_BORDER_THICKNESS /* v */,
 						get3x3HotbarTopLeftX(context) + HOTBAR_BORDER_THICKNESS, get3x3HotbarTopLeftY(context) + HOTBAR_BORDER_THICKNESS + row * HOTBAR_SLOT_SIZE,
@@ -145,15 +148,16 @@ public abstract class InGameHudMixin {
 		}
 	}
 
-	@Redirect(method="renderHotbar", at=@At(value="INVOKE", target="Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1))
-	private void drawHotbarSelectionTexture(DrawContext context, Identifier _texture, int _x, int _y, int _width, int _height) {
+	@Redirect(method="renderHotbar", at=@At(value="INVOKE", target="Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIII)V", ordinal = 1))
+	private void drawHotbarSelectionTexture(DrawContext context, Function<Identifier, RenderLayer> renderLayers, Identifier _texture, int _x, int _y, int _width, int _height) {
 		int selectedSlot = this.getCameraPlayer().getInventory().selectedSlot;
 
 		context.drawGuiTexture(
-				HOTBAR_SELECTION_TEXTURE,  getHotbarSlotTopLeftX(context, selectedSlot) - 2, getHotbarSlotTopLeftY(context, selectedSlot) - 2, 24, 23
+				renderLayers, HOTBAR_SELECTION_TEXTURE,  getHotbarSlotTopLeftX(context, selectedSlot) - 2, getHotbarSlotTopLeftY(context, selectedSlot) - 2, 24, 23
 		);
 
 		context.drawGuiTexture( // draw bottom border using top border of selection texture
+				renderLayers,
 				HOTBAR_SELECTION_TEXTURE,
 				24, 23,
 				0, 0,

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,11 +29,11 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.21",
+		"fabricloader": ">=0.16.8",
+		"minecraft": "~1.21.3",
 		"java": ">=21",
 		"fabric-api": "*",
-		"cloth-config": "~15.0",
-		"modmenu": "~11.0.1"
+		"cloth-config": "~16.0",
+		"modmenu": [">=12.0.0-beta.1", "<=12.1.0"]
 	}
 }


### PR DESCRIPTION
Minecraft (of course) had ot change the way ui rendering works with 1.21.2. As a result, your mod has stopped working on 1.21.2 and 1.21.3. Because I'm using your mod, I decided to update it myself.

Changed made include:
- Update the fabric loom version to 1.8-SNAPSHOT (which required a Gradle Update to 8.10)
- Update the mod dependencies to their 1.21.2/3 versions.
- Set fabric loader version to 1.16.8 (required by fabric-api)
- Updated yarn mappings to 1.21.3+build.2
- Set mod version to 1.0.0+MC1.21.3 to differentiate it with the with the older version compatible with 1.21
- Updated the code to work with 1.21.3.

If you have any questions, or requests for changes, feel free to reply here.